### PR TITLE
Android options validation

### DIFF
--- a/src/library/package-utils.ts
+++ b/src/library/package-utils.ts
@@ -182,7 +182,7 @@ export async function buildAndroidOptions() {
     }
 
     // make sure we have manifestUrl and packageId first
-    if (advancedSettings) {
+    if (advancedSettings && advancedSettings.label === "Yes") {
       // handle advanced settings
       const uri = await vscode.window.showSaveDialog({
         title: "Save advanced Android settings file to continue",

--- a/src/library/package-utils.ts
+++ b/src/library/package-utils.ts
@@ -4,8 +4,11 @@ import { Headers } from "node-fetch";
 import { MsixInfo } from "../interfaces";
 
 import * as vscode from "vscode";
+import { AndroidPackageOptions } from "../services/package/package-android-app";
 
-const advancedAndroidSettings = {
+export const WindowsDocsURL = "https://blog.pwabuilder.com/docs/windows-platform/";
+
+const advancedAndroidSettings: AndroidPackageOptions = {
   appVersion: "1.0.0.0",
   appVersionCode: 1,
   backgroundColor: "#FFFFFF",
@@ -24,6 +27,7 @@ const advancedAndroidSettings = {
   host: "https://myapp.com",
   iconUrl: "https://myapp.com/icon.png",
   maskableIconUrl: "https://myapp.com/maskable-icon.png",
+  monochromeIconUrl: "https://myapp.com/monochrome-icon.png",
   includeSourceCode: false,
   isChromeOSOnly: false,
   launcherName: "app name", // launcher name should be the short name. If none is available, fallback to the full app name.
@@ -49,7 +53,7 @@ const advancedAndroidSettings = {
   splashScreenFadeOutDuration: 300,
   startUrl: "/",
   themeColor: "#FFFFFF",
-  shareTarget: [],
+  shareTarget: ([] as any),
   webManifestUrl: "https://myapp.com/manifest.json",
 };
 
@@ -99,7 +103,7 @@ export function getPublisherMsixFromArray(...args: string[]): MsixInfo {
   };
 }
 
-export async function buildAndroidPackage(options: any) {
+export async function buildAndroidPackage(options: AndroidPackageOptions) {
   const generateAppUrl = `https://pwabuilder-cloudapk.azurewebsites.net/generateAppPackage`;
   const response = await fetch(generateAppUrl, {
     method: "POST",
@@ -110,7 +114,7 @@ export async function buildAndroidPackage(options: any) {
   return response;
 }
 
-export async function buildAndroidOptions() {
+export async function buildAndroidOptions(): Promise<AndroidPackageOptions | undefined> {
   const appUrl = await vscode.window.showInputBox({
     prompt: "Enter the URL to your app",
   });
@@ -247,6 +251,7 @@ export async function buildAndroidOptions() {
       host: appUrl,
       iconUrl: `${appUrl}/${icon.src}`,
       maskableIconUrl: maskableIcon ? `${appUrl}/${maskableIcon.src}` : null,
+      monochromeIconUrl: null,
       includeSourceCode: false,
       isChromeOSOnly: false,
       launcherName: manifest.short_name.substring(0, 30), // launcher name should be the short name. If none is available, fallback to the full app name.

--- a/src/services/package/package-android-app.ts
+++ b/src/services/package/package-android-app.ts
@@ -1,6 +1,459 @@
 import { buildAndroidPackage } from "../../library/package-utils";
 
 export async function packageForAndroid(options: any): Promise<any> {
-    const responseData = await buildAndroidPackage(options);
-    return await responseData.blob();
+  const responseData = await buildAndroidPackage(options);
+  return await responseData.blob();
+}
+
+// below code pulled from the main PWABuilder site
+export interface ShortcutItem {
+  name: string;
+  url: string;
+  description?: string;
+  short_name?: string;
+  icons?: Icon[];
+}
+
+export interface Icon {
+  src: string;
+  generated?: boolean;
+  type?: string;
+  sizes?: string;
+  purpose?: "any" | "maskable" | "monochrome";
+  label?: string;
+}
+
+export interface ShareTarget {
+  action?: string;
+  method?: string;
+  enctype?: string;
+  params?: ShareTargetParams;
+}
+
+export interface ShareTargetParams {
+  title?: string;
+  text?: string;
+  url?: string;
+  files?: FilesParams[];
+}
+
+export interface FilesParams {
+  name: string;
+  accept: string[];
+}
+
+/**
+ * Settings for the Android APK generation. This is the raw data passed to the CloudApk service.
+ * It should match the CloudApk service's AndroidPackageOptions interface: https://github.com/pwa-builder/CloudAPK/blob/master/build/androidPackageOptions.ts
+ */
+export interface AndroidPackageOptions {
+  appVersion: string;
+  appVersionCode: number;
+  backgroundColor: string;
+  display: "standalone" | "fullscreen" | "fullscreen-sticky";
+  enableNotifications: boolean;
+  enableSiteSettingsShortcut: boolean;
+  fallbackType: "customtabs" | "webview";
+  features: {
+    appsFlyer?: {
+      enabled: boolean;
+      appsFlyerId: string;
+    };
+    locationDelegation?: {
+      enabled: boolean;
+    };
+    playBilling?: {
+      enabled: boolean;
+    };
+    firstRunFlag?: {
+      enabled: boolean;
+      queryParameterName: string;
+    };
+  };
+  host: string;
+  iconUrl: string;
+  includeSourceCode: boolean;
+  isChromeOSOnly: boolean;
+  launcherName: string;
+  maskableIconUrl: string | null;
+  monochromeIconUrl: string | null;
+  name: string;
+  navigationColor: string;
+  navigationColorDark: string;
+  navigationDividerColor: string;
+  navigationDividerColorDark: string;
+  orientation:
+    | "default"
+    | "any"
+    | "natural"
+    | "landscape"
+    | "portrait"
+    | "portrait-primary"
+    | "portrait-secondary"
+    | "landscape-primary"
+    | "landscape-secondary";
+  packageId: string;
+  shareTarget?: ShareTarget;
+  shortcuts: ShortcutItem[];
+  signing: AndroidSigningOptions;
+  signingMode: "new" | "none" | "mine";
+  splashScreenFadeOutDuration: number;
+  startUrl: string;
+  themeColor: string;
+  webManifestUrl: string;
+}
+
+/**
+ * Signing options for Android APK generation. This is sent to the Cloud APK service as part of AndroidApkOptions.
+ * It should generally match the CloudApk service's SigningOptions interface: https://github.com/pwa-builder/CloudAPK/blob/master/build/signingOptions.ts
+ */
+export interface AndroidSigningOptions {
+  /**
+   * The base64 encoded contents of the Android .keystore file.
+   * This can be null when signing mode is "none" or "new".
+   */
+  file: string | null;
+  alias: string;
+  fullName: string;
+  organization: string;
+  organizationalUnit: string;
+  countryCode: string;
+  keyPassword: string;
+  storePassword: string;
+}
+
+type AndroidPackageValidationError = {
+  field: keyof AndroidPackageOptions | keyof AndroidSigningOptions | null;
+  error: string;
+};
+
+const DISALLOWED_ANDROID_PACKAGE_CHARS_REGEX = /[^a-zA-Z0-9_]/g;
+
+export const maxSigningKeySizeInBytes = 2097152;
+
+export function generatePackageId(host: string): string {
+  const parts = host
+    .split(".")
+    .reverse()
+    .map((p) => p.trim().toLowerCase())
+    .map((p) => withoutLeadingDigits(p)) // Android Package name parts can't begin with numbers: https://github.com/pwa-builder/PWABuilder/issues/1336#issuecomment-755029058
+    .filter((p) => p.length > 0)
+    .map((p) => p.replace(DISALLOWED_ANDROID_PACKAGE_CHARS_REGEX, "_"));
+  parts.push("twa");
+
+  return parts.join(".");
+}
+
+export function validateAndroidOptions(
+  options: Partial<AndroidPackageOptions | null>
+): AndroidPackageValidationError[] {
+  const validationErrors: AndroidPackageValidationError[] = [];
+  if (!options) {
+    validationErrors.push({ field: null, error: "No options specified " });
+    return validationErrors;
+  }
+
+  if (!options.packageId) {
+    validationErrors.push({ field: "packageId", error: "No package ID" });
+  }
+
+  if (options.packageId && options.packageId.search(/[^a-zA-Z0-9-_.]/) !== -1) {
+    validationErrors.push({
+      field: "packageId",
+      error:
+        "Package ID must not contain any character other than alphanumeric, period, hyphen, and underscore.",
+    });
+  }
+
+  // Package ID can't contain ".if.", can't start with "if.", and can't end with ".if"
+  // See https://github.com/pwa-builder/PWABuilder/issues/2146
+  if (
+    options.packageId &&
+    (options.packageId.includes(".if.") ||
+      options.packageId.startsWith("if.") ||
+      options.packageId?.endsWith(".if"))
+  ) {
+    validationErrors.push({
+      field: "packageId",
+      error:
+        'Package ID must not contain ".if.", must not start with "if.", and must not end with ".if"',
+    });
+  }
+
+  if (!options.name || options.name.trim().length === 0) {
+    validationErrors.push({
+      field: "name",
+      error: "Must have a valid app name",
+    });
+  }
+
+  if (options.name && (options.name.length < 3 || options.name.length > 50)) {
+    validationErrors.push({
+      field: "name",
+      error: "Name must not be between 3 and 50 characters in length",
+    });
+  }
+
+  if (
+    options.launcherName &&
+    (options.launcherName.length < 3 || options.launcherName.length > 30)
+  ) {
+    validationErrors.push({
+      field: "launcherName",
+      error: "Launcher name must be between 3 and 30 characters in length",
+    });
+  }
+
+  if (!options.appVersion || options.appVersion.trim().length === 0) {
+    validationErrors.push({
+      field: "appVersion",
+      error: "Must have a valid app version",
+    });
+  }
+
+  if (!options.appVersionCode || options.appVersionCode > 2100000000) {
+    validationErrors.push({
+      field: "appVersionCode",
+      error: "App version code must be between 1 and 2,100,000,000",
+    });
+  }
+
+  if (!options.backgroundColor) {
+    validationErrors.push({
+      field: "backgroundColor",
+      error: "Must have a background color",
+    });
+  }
+
+  if (
+    options.display !== "standalone" &&
+    options.display !== "fullscreen" &&
+    options.display !== "fullscreen-sticky"
+  ) {
+    validationErrors.push({
+      field: "display",
+      error: "Display must be 'standalone' or 'fullscreen'",
+    });
+  }
+
+  if (
+    options.fallbackType !== "customtabs" &&
+    options.fallbackType !== "webview"
+  ) {
+    validationErrors.push({
+      field: "fallbackType",
+      error: "Fallback type must be 'customtabs' or 'webview'",
+    });
+  }
+
+  if (!options.host) {
+    validationErrors.push({ field: "host", error: "Host must be specified" });
+  } else {
+    const hostWithProtocol = options.host.startsWith("https")
+      ? options.host
+      : `https://${options.host}`;
+    const hostUrlError = validateUrl(hostWithProtocol);
+    if (hostUrlError) {
+      validationErrors.push({
+        field: "host",
+        error: "Host URL must be a valid URL",
+      });
+    }
+  }
+
+  if (!options.iconUrl) {
+    validationErrors.push({ field: "iconUrl", error: "Must have a icon URL" });
+  } else {
+    const iconUrlError = validateUrl(options.iconUrl, options.webManifestUrl);
+    if (iconUrlError) {
+      validationErrors.push({ field: "iconUrl", error: "Icon URL is invalid" });
+    }
+  }
+
+  if (!options.launcherName || options.launcherName.trim().length === 0) {
+    validationErrors.push({
+      field: "launcherName",
+      error: "Must have an app launcher name",
+    });
+  }
+
+  if (!options.webManifestUrl) {
+    validationErrors.push({
+      field: "webManifestUrl",
+      error: "Must have a manifest URL",
+    });
+  } else {
+    const manifestUrlError = validateUrl(options.webManifestUrl);
+    if (manifestUrlError) {
+      validationErrors.push({
+        field: "webManifestUrl",
+        error: "Manifest URL is invalid",
+      });
+    }
+  }
+
+  // Maskable icon is optional. But if it's specified, it must be a valid URL.
+  if (options.maskableIconUrl) {
+    const maskableIconError = validateUrl(
+      options.maskableIconUrl,
+      options.webManifestUrl
+    );
+    if (maskableIconError) {
+      validationErrors.push({
+        field: "maskableIconUrl",
+        error:
+          "Maskable icon URL was invalid. If you specify a maskable icon URL, it must be a valid URL.",
+      });
+    }
+  }
+
+  // monochrome icon is also optional.
+  if (options.monochromeIconUrl) {
+    const monochromeIconError = validateUrl(
+      options.monochromeIconUrl,
+      options.webManifestUrl
+    );
+    if (monochromeIconError) {
+      validationErrors.push({
+        field: "monochromeIconUrl",
+        error:
+          "Monochrome icon URL was invalid. If you specify a monochrome icon URL, it must be a valid URL.",
+      });
+    }
+  }
+
+  if (!options.navigationColor) {
+    validationErrors.push({
+      field: "navigationColor",
+      error: "Navigation color is required",
+    });
+  }
+
+  // Validating signing options when we have a signing mode
+  if (options.signingMode === "mine" || options.signingMode === "new") {
+    if (!options.signing) {
+      validationErrors.push({
+        field: "signing",
+        error: "Signing information must be supplied.",
+      });
+    } else {
+      // Full name, organization, organizational unit, and country are required if signingMode !== mine
+      // File is required only signingMode === "mine"
+      // Store password and key password are required only if signingMode === "mine"; otherwise, they're optional and CloudAPK will generate a new password for you.
+      const requiredSigningFields: Array<keyof AndroidSigningOptions> = [
+        "alias",
+      ];
+      if (options.signingMode === "mine") {
+        requiredSigningFields.push("file", "keyPassword", "storePassword");
+      } else if (options.signingMode === "new") {
+        // New key? We require these details to create the key.
+        requiredSigningFields.push(
+          "fullName",
+          "organization",
+          "organizationalUnit",
+          "countryCode"
+        );
+      }
+
+      requiredSigningFields
+        .filter((prop) => !options.signing![prop])
+        .forEach((prop) =>
+          validationErrors.push({
+            field: prop,
+            error: `${prop.toString()} must be specified`,
+          })
+        );
+
+      // If key password and store password are specified, they must be >= 6 chars in length.
+      if (
+        options.signing.keyPassword &&
+        options.signing.keyPassword.length < 6
+      ) {
+        validationErrors.push({
+          field: "keyPassword",
+          error: "Key password must be at least 6 characters",
+        });
+      }
+      if (
+        options.signing.storePassword &&
+        options.signing.storePassword.length < 6
+      ) {
+        validationErrors.push({
+          field: "storePassword",
+          error: "Key store password must be at least 6 characters",
+        });
+      }
+
+      // Ensure country code is 2 chars
+      if (
+        options.signingMode === "new" &&
+        options.signing.countryCode &&
+        options.signing.countryCode.length !== 2
+      ) {
+        validationErrors.push({
+          field: "countryCode",
+          error: "Signing key country code must be 2 letters",
+        });
+      }
+    }
+  }
+
+  if (
+    options.splashScreenFadeOutDuration === null ||
+    options.splashScreenFadeOutDuration === undefined ||
+    options.splashScreenFadeOutDuration < 0
+  ) {
+    validationErrors.push({
+      field: "splashScreenFadeOutDuration",
+      error: "Splash screen fade duration must be 0 or greater",
+    });
+  }
+
+  if (!options.startUrl) {
+    validationErrors.push({
+      field: "startUrl",
+      error:
+        "Start URL must be specified. If your start URL is the same as Host, you can use '/' as the start URL.",
+    });
+  } else {
+    const startUrlError = validateUrl(options.startUrl, options.webManifestUrl);
+    if (startUrlError) {
+      validationErrors.push({
+        field: "startUrl",
+        error: "Start URL is invalid",
+      });
+    }
+  }
+
+  if (!options.themeColor) {
+    validationErrors.push({
+      field: "themeColor",
+      error: "Theme color must be specified",
+    });
+  }
+
+  return validationErrors;
+}
+
+export function validateUrl(url: string, base?: string): string | null {
+  try {
+    new URL(url, base);
+    return null;
+  } catch (urlError) {
+    return `${urlError}`;
+  }
+}
+
+function withoutLeadingDigits(input: string): string {
+  if (input.length === 0) {
+    return "app";
+  }
+
+  // Check if it starts with a digit.
+  // If so, prepend "app" to it.
+  if (input && input.length && input[0]!.match(/^\d/)) {
+    return `app_${input}`;
+  }
+
+  return input;
 }

--- a/src/services/package/package-android-app.ts
+++ b/src/services/package/package-android-app.ts
@@ -5,6 +5,8 @@ export async function packageForAndroid(options: any): Promise<any> {
   return await responseData.blob();
 }
 
+export const AndroidDocsURL = "https://blog.pwabuilder.com/docs/testing-and-publishing-your-android-pwa-to-the-google-play-store";
+
 // below code pulled from the main PWABuilder site
 export interface ShortcutItem {
   name: string;

--- a/src/services/package/package-app.ts
+++ b/src/services/package/package-app.ts
@@ -14,8 +14,10 @@ import {
   getPublisherMsixFromArray,
   getSimpleMsixFromArray,
   packageForWindows,
+  WindowsDocsURL,
 } from "../../library/package-utils";
 import {
+  AndroidDocsURL,
   packageForAndroid,
   validateAndroidOptions,
 } from "./package-android-app";
@@ -49,6 +51,9 @@ export async function packageApp(): Promise<void> {
               const responseData: Blob = await packageForAndroid(options);
               progress.report({ message: "Converting to zip..." });
               await convertPackageToZip(responseData, options.packageId);
+
+              // open android docs
+              await vscode.env.openExternal(vscode.Uri.parse(AndroidDocsURL));
             } else {
               // validation errors
               await vscode.window.showErrorMessage(
@@ -80,6 +85,9 @@ export async function packageApp(): Promise<void> {
           const responseData: any = await packageWithPwaBuilder();
           progress.report({ message: "Converting to zip..." });
           await convertPackageToZip(responseData);
+
+          // open windows docs
+          await vscode.env.openExternal(vscode.Uri.parse(WindowsDocsURL));
         }
       );
     }

--- a/src/services/package/package-app.ts
+++ b/src/services/package/package-app.ts
@@ -15,7 +15,10 @@ import {
   getSimpleMsixFromArray,
   packageForWindows,
 } from "../../library/package-utils";
-import { packageForAndroid, validateAndroidOptions } from "./package-android-app";
+import {
+  packageForAndroid,
+  validateAndroidOptions,
+} from "./package-android-app";
 
 const inputCancelledMessage: string =
   "Input process cancelled. Try again if you wish to package your PWA";
@@ -40,12 +43,21 @@ export async function packageApp(): Promise<void> {
           const options = await getAndroidPackageOptions();
           if (options) {
             const optionsValidation = await validateAndroidOptions(options);
-            console.log('optionsValidation', optionsValidation);
 
-            /*
-            const responseData: Blob = await packageForAndroid(options);
-            progress.report({ message: "Converting to zip..." });
-            await convertPackageToZip(responseData, options.packageId);*/
+            if (optionsValidation.length === 0) {
+              // no validation errors
+              const responseData: Blob = await packageForAndroid(options);
+              progress.report({ message: "Converting to zip..." });
+              await convertPackageToZip(responseData, options.packageId);
+            } else {
+              // validation errors
+              await vscode.window.showErrorMessage(
+                `There are some problems with your manifest that have prevented us from packaging: ${optionsValidation.join(
+                  "\n"
+                )}`
+              );
+              return;
+            }
           }
         }
       );

--- a/src/services/package/package-app.ts
+++ b/src/services/package/package-app.ts
@@ -15,7 +15,7 @@ import {
   getSimpleMsixFromArray,
   packageForWindows,
 } from "../../library/package-utils";
-import { packageForAndroid } from "./package-android-app";
+import { packageForAndroid, validateAndroidOptions } from "./package-android-app";
 
 const inputCancelledMessage: string =
   "Input process cancelled. Try again if you wish to package your PWA";
@@ -39,9 +39,13 @@ export async function packageApp(): Promise<void> {
           progress.report({ message: "Packaging your app..." });
           const options = await getAndroidPackageOptions();
           if (options) {
+            const optionsValidation = await validateAndroidOptions(options);
+            console.log('optionsValidation', optionsValidation);
+
+            /*
             const responseData: Blob = await packageForAndroid(options);
             progress.report({ message: "Converting to zip..." });
-            await convertPackageToZip(responseData, options.packageId);
+            await convertPackageToZip(responseData, options.packageId);*/
           }
         }
       );


### PR DESCRIPTION
This PR implements: 
- Validating Android options before packaging. https://github.com/pwa-builder/PWABuilder/issues/2330
- open docs for each platform after packaging. (open Android docs if user has packaged with Android, same for Windows) https://github.com/pwa-builder/PWABuilder/issues/2331