### PR TITLE
Upgrade Service Worker flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "onCommand:pwa-studio.serviceWorker",
     "onCommand:pwa-studio.validatePWA",
     "onCommand:pwa-studio.manifest",
-    "onCommand:pwa-studio.packageApp"
+    "onCommand:pwa-studio.packageApp",
+    "onCommand:pwa-studio.generateWorker"
   ],
   "main": "./out/extension.js",
   "contributes": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,12 +2,13 @@
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from "vscode";
 import { setUpLocalPwaStarterRepository } from "./services/new-pwa-starter";
-import { handleServiceWorkerCommand } from "./services/service-worker";
+import { handleServiceWorkerCommand, generateServiceWorker } from "./services/service-worker";
 import { handleManifestCommand } from "./services/manifest/manifest-service";
 import { packageApp } from "./services/package/package-app";
 import { handleValidation } from "./services/validation";
 
 const serviceWorkerCommandId = "pwa-studio.serviceWorker";
+const generateWorkerCommandId = "pwa-studio.generateWorker";
 const newPWAStarterCommandId = "pwa-studio.newPwaStarter";
 const validateCommandId = "pwa-studio.validatePWA";
 const packageCommandId = "pwa-studio.packageApp";
@@ -19,7 +20,7 @@ export function activate(context: vscode.ExtensionContext) {
     100
   );
 
-  myStatusBarItem.text = "Update Service Worker";
+  myStatusBarItem.text = "Generate Service Worker";
 
   const addServiceWorker = vscode.commands.registerCommand(
     serviceWorkerCommandId,
@@ -29,7 +30,15 @@ export function activate(context: vscode.ExtensionContext) {
     }
   );
 
-  myStatusBarItem.command = serviceWorkerCommandId;
+  const generateWorker = vscode.commands.registerCommand(
+    generateWorkerCommandId,
+    async () => {
+      await generateServiceWorker();
+      myStatusBarItem.show();
+    }
+  );
+
+  myStatusBarItem.command = generateWorkerCommandId;
 
   let packageAppCommand = vscode.commands.registerCommand(
     packageCommandId,
@@ -61,6 +70,7 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(myStatusBarItem);
   context.subscriptions.push(packageAppCommand);
   context.subscriptions.push(validationCommand);
+  context.subscriptions.push(generateWorker);
 }
 
 export function deactivate() {}

--- a/src/services/new-pwa-starter.ts
+++ b/src/services/new-pwa-starter.ts
@@ -68,7 +68,7 @@ function changeDirectory(pathToDirectory: string | undefined): void {
   vsTerminal.sendText(`cd ${pathToDirectory}`);
 }
 
-function isNpmInstalled(): boolean {
+export function isNpmInstalled(): boolean {
   var isNpmInstalled: boolean = true;
 
   if (!shell.which("npm")) {
@@ -116,6 +116,6 @@ function noGitInstalledWarning(): void {
   vscode.window.showWarningMessage(noGitWarning);
 }
 
-function noNpmInstalledWarning(): void {
+export function noNpmInstalledWarning(): void {
   vscode.window.showWarningMessage(noNpmWarning);
 }

--- a/src/services/service-worker.ts
+++ b/src/services/service-worker.ts
@@ -1,62 +1,70 @@
 import * as vscode from "vscode";
+import { isNpmInstalled, noNpmInstalledWarning } from "./new-pwa-starter";
 
 const workboxBuild = require("workbox-build");
 
+const vsTerminal = vscode.window.createTerminal();
+
 export async function handleServiceWorkerCommand(): Promise<void> {
-  vscode.window.showInformationMessage(
-    "Your build directory is where your code is compiled to. With most setups this will be either `dist` or `build`. Check the documentation for your framework for more information."
-  );
-
-  const buildDir = await vscode.window.showOpenDialog({
-    canSelectFiles: false,
-    canSelectFolders: true,
-    canSelectMany: false,
-    title: "Select your build directory",
-  });
-
-  if (buildDir) {
-    const serviceWorkerFileName = await vscode.window.showInputBox({
-      title: "Service Worker File Name",
-      value: "service-worker.js",
-      prompt: "What would you like your service worker file to be called?",
-      placeHolder: "service-worker.js",
-    });
-
-    if (serviceWorkerFileName) {
-      try {
-        vscode.window.withProgress(
-          {
-            location: vscode.ProgressLocation.Notification,
-          },
-          async (progress) => {
-            progress.report({ message: "Building service worker..." });
-            await runWorkboxTool(buildDir[0].fsPath, serviceWorkerFileName);
-            progress.report({ message: "Service worker added!" });
-          }
-        );
-
-        await handleAddingToIndex();
-      } catch (err) {
-        vscode.window.showErrorMessage(
-          err && (err as Error).message
-            ? (err as Error).message
-            : "There was an issue adding your service worker"
-        );
+  try {
+    vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+      },
+      async (progress) => {
+        progress.report({ message: "Building service worker..." });
+        await runWorkboxTool();
+        progress.report({ message: "Service worker added!" });
       }
-    }
+    );
+
+    await handleAddingToIndex();
+
+    vscode.window.showInformationMessage(
+      "When you are ready to generate your Service Worker, tap the 'Generate Service Worker' button in the status bar below."
+    );
+
+    await vscode.window.showInformationMessage(
+      "Check the Workbox documentation to add workbox to your existing build command.",
+      {},
+      {
+        title: "Open Workbox Documentation",
+        action: async () => {
+          await vscode.env.openExternal(
+            vscode.Uri.parse(
+              "https://developers.google.com/web/tools/workbox/modules/workbox-cli#setup_and_configuration"
+            )
+          );
+        },
+      }
+    );
+  } catch (err) {
+    vscode.window.showErrorMessage(
+      err && (err as Error).message
+        ? (err as Error).message
+        : "There was an issue adding your service worker"
+    );
   }
 }
 
-async function runWorkboxTool(buildDir: string, fileName: string): Promise<unknown> {
+export function generateServiceWorker() {
+  vsTerminal.show();
+  vsTerminal.sendText("workbox generateSW");
+}
+
+async function runWorkboxTool(): Promise<void> {
   return new Promise(async (resolve, reject) => {
     try {
-      const data = await workboxBuild.generateSW({
-        globDirectory: `${buildDir}`,
-        globPatterns: ["**/*.{html,json,js,css}"],
-        inlineWorkboxRuntime: true,
-        swDest: `${vscode.workspace.workspaceFolders?.[0].uri.fsPath}/${fileName}`,
-      });
-      resolve(data);
+      const npmCheck = isNpmInstalled();
+      if (npmCheck) {
+        vsTerminal.show();
+        vsTerminal.sendText("npm install workbox-cli --global");
+
+        vsTerminal.sendText("workbox wizard");
+        resolve();
+      } else {
+        noNpmInstalledWarning();
+      }
     } catch (err) {
       reject(err);
     }

--- a/src/services/service-worker.ts
+++ b/src/services/service-worker.ts
@@ -1,8 +1,6 @@
 import * as vscode from "vscode";
 import { isNpmInstalled, noNpmInstalledWarning } from "./new-pwa-starter";
 
-const workboxBuild = require("workbox-build");
-
 const vsTerminal = vscode.window.createTerminal();
 
 export async function handleServiceWorkerCommand(): Promise<void> {


### PR DESCRIPTION
We now use the workbox-cli with the vsTerminal API. This enables:
- User can pick and choose which assets they want to cache
- Settings get copied to a file, making updating the service worker much easier
- Workbox handles the complicated parts of choosing your build directory etc
- We now open Workbox docs at the end of the flow
- User can now generate service worker from a button in the status bar