### PR TITLE
fixes https://github.com/pwa-builder/PWABuilder/issues/2579

### DIFF
--- a/src/services/new-pwa-starter.ts
+++ b/src/services/new-pwa-starter.ts
@@ -164,7 +164,3 @@ function noGitInstalledWarning(): void {
 export function noNpmInstalledWarning(): void {
   vscode.window.showWarningMessage(noNpmWarning);
 }
-function folders(arg0: () => void, readonly: any, folders: any, arg3: readonly vscode.WorkspaceFolder[] | undefined): vscode.Disposable {
-  throw new Error("Function not implemented.");
-}
-


### PR DESCRIPTION
[Link](https://github.com/pwa-builder/PWABuilder/issues/2579) to associated issue.

**Old behavior:**
PWA starter clones from the extension and cloned repo is still pointing at the PWA starter template repository.

**New behavior:**
PWA starter clones and inits itself as new local repo with no upstream origin. Repo can now be easily associated with an upstream origin if desired.